### PR TITLE
Upgrade Helidon ToDo to use Coherence 21.06.2

### DIFF
--- a/java/helidon-server/README.md
+++ b/java/helidon-server/README.md
@@ -27,7 +27,7 @@ mvn exec:exec
    
 ### Access the Web UI
   
-Access via http://localhost:3000/
+Access via http://localhost:7001/
    
 ![To Do List - React Client](../../assets/react-client.png)
    

--- a/java/helidon-server/pom.xml
+++ b/java/helidon-server/pom.xml
@@ -74,11 +74,6 @@
       <artifactId>coherence-mp-config</artifactId>
       <version>${coherence.version}</version>
     </dependency>
-    <dependency>
-      <groupId>${coherence.groupId}</groupId>
-      <artifactId>coherence-mp-metrics</artifactId>
-      <version>${coherence.version}</version>
-    </dependency>
   </dependencies>
 
   <build>
@@ -120,6 +115,7 @@
         <configuration>
           <executable>java</executable>
           <arguments>
+            <argument>-Dcoherence.metrics.http.enabled=true</argument>
             <argument>-classpath</argument>
             <classpath/>
             <argument>io.helidon.microprofile.cdi.Main</argument>

--- a/java/helidon-server/pom.xml
+++ b/java/helidon-server/pom.xml
@@ -24,6 +24,8 @@
   <properties>
     <coherence.groupId>com.oracle.coherence.ce</coherence.groupId>
     <coherence.version>${project.version}</coherence.version>
+    <version.lib.hamcrest>2.2</version.lib.hamcrest>
+    <version.lib.rest-assured>4.3.3</version.lib.rest-assured>
   </properties>
 
   <dependencies>
@@ -74,6 +76,33 @@
       <artifactId>coherence-mp-config</artifactId>
       <version>${coherence.version}</version>
     </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${version.lib.junit}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${version.lib.junit}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>${version.lib.hamcrest}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>${version.lib.rest-assured}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -196,6 +225,23 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <systemPropertyVariables>
+            <coherence.metrics.http.enabled>true</coherence.metrics.http.enabled>
+          </systemPropertyVariables>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/java/helidon-server/pom.xml
+++ b/java/helidon-server/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>com.oracle.coherence.examples</groupId>
   <artifactId>todo-list-helidon-server</artifactId>
-  <version>21.06.1</version>
+  <version>21.06.2</version>
 
   <properties>
     <coherence.groupId>com.oracle.coherence.ce</coherence.groupId>

--- a/java/helidon-server/src/test/java/com/oracle/coherence/examples/todo/server/MetricsIT.java
+++ b/java/helidon-server/src/test/java/com/oracle/coherence/examples/todo/server/MetricsIT.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl.
+ */
+
 package com.oracle.coherence.examples.todo.server;
 
 import io.helidon.microprofile.server.Server;

--- a/java/helidon-server/src/test/java/com/oracle/coherence/examples/todo/server/MetricsIT.java
+++ b/java/helidon-server/src/test/java/com/oracle/coherence/examples/todo/server/MetricsIT.java
@@ -1,0 +1,71 @@
+package com.oracle.coherence.examples.todo.server;
+
+import io.helidon.microprofile.server.Server;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.is;
+
+public class MetricsIT {
+	protected static Server SERVER;
+
+	@BeforeAll
+	static void startServer() {
+		SERVER = Server.builder().port(0).build().start();
+	}
+
+	@AfterAll
+	static void stopServer() {
+		SERVER.stop();
+	}
+
+	@BeforeEach
+	void setup() {
+		RestAssured.reset();
+		RestAssured.baseURI = "http://localhost";
+	}
+
+	@Test
+	void testCreateTask() {
+		given().
+				port(SERVER.port()).
+				contentType(JSON).
+				body(Collections.singletonMap("description", "hello")).
+		when().
+				post("/api/tasks").
+		then().
+				log().all().
+				statusCode(OK.getStatusCode()).
+				body("description", is("hello"),
+						"completed", is(false));
+
+		given().
+				port(9612).
+				accept(JSON).
+		when().
+				get("/metrics").
+		then().
+				statusCode(200);
+
+		given().
+				port(9612).
+				accept(JSON).
+		when().
+				get("/metrics/Coherence.Cache.Size?name=tasks&tier=back").
+		then().
+				log().all().
+				statusCode(200).
+		assertThat().
+				body("size()", is(1)).
+		        body("[0].tags.name", is("tasks"),
+						"[0].value", is(1));
+	}
+}


### PR DESCRIPTION
- update Helidon ToDo to use built-in Coherence metrics
- add integration tests for the metrics endpoint