### PR TITLE
Upgrade Coherence dependency to 23.09.2

### DIFF
--- a/java/micronaut-server/README.md
+++ b/java/micronaut-server/README.md
@@ -19,7 +19,7 @@ mvn clean package
 ### Maven
 
 ```bash  
-java -jar target/todo-list-micronaut-server-23.09-shaded.jar
+java -jar target/todo-list-micronaut-server-23.09.2-shaded.jar
 ```
 
 ## Building a Docker Image

--- a/java/micronaut-server/pom.xml
+++ b/java/micronaut-server/pom.xml
@@ -61,7 +61,7 @@
 
   <groupId>com.oracle.coherence.examples</groupId>
   <artifactId>todo-list-micronaut-server</artifactId>
-  <version>23.09</version>
+  <version>23.09.2</version>
 
   <properties>
     <java.version>17</java.version>
@@ -74,8 +74,8 @@
     <!-- Micronaut properties -->
     <micronaut.runtime>netty</micronaut.runtime>
     <micronaut.version>${project.parent.version}</micronaut.version>
-    <micronaut.test.version>4.0.0</micronaut.test.version>
-    <micronaut.gql.version>4.2.0</micronaut.gql.version>
+    <micronaut.test.version>4.2.0</micronaut.test.version>
+    <micronaut.gql.version>4.2.1</micronaut.gql.version>
 
     <!-- Native image properties -->
     <micronaut.processing.group>todo.list.micronaut.server</micronaut.processing.group>
@@ -84,22 +84,24 @@
     <!-- Coherence+Micronaut integration properties -->
     <micronaut.coherence.version>5.0.1</micronaut.coherence.version>
 
-    <!-- Additional test dependencies -->
+    <!-- Additional dependencies -->
     <hamcrest.version>2.2</hamcrest.version>
-    <logback.version>1.2.13</logback.version>
-    <restassured.version>5.1.1</restassured.version>
-    <junit.version>5.8.2</junit.version>
+    <jansi.version>2.4.1</jansi.version>
+    <logback.version>1.4.14</logback.version>
+    <restassured.version>5.4.0</restassured.version>
+    <rxjava.version>2.2.21</rxjava.version>
+    <junit.version>5.10.1</junit.version>
 
     <!-- Maven plugin properties -->
     <plugin.jandex.version>1.2.3</plugin.jandex.version>
-    <plugin.exec.version>3.1.0</plugin.exec.version>
+    <plugin.exec.version>3.1.1</plugin.exec.version>
     <plugin.npm.version>1.0.4</plugin.npm.version>
-    <plugin.resources.version>3.1.0</plugin.resources.version>
+    <plugin.resources.version>3.3.1</plugin.resources.version>
     <plugin.jib.version>3.3.1</plugin.jib.version>
-    <plugin.compiler.version>3.11.0</plugin.compiler.version>
+    <plugin.compiler.version>3.12.1</plugin.compiler.version>
     <plugin.micronaut.version>4.3.1</plugin.micronaut.version>
 
-    <frontend-maven-plugin.version>1.12.1</frontend-maven-plugin.version>
+    <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
     <node.version>v14.17.6</node.version>
     <exec.mainClass>com.oracle.coherence.examples.todo.server.Application</exec.mainClass>
   </properties>
@@ -179,13 +181,18 @@
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
-      <version>2.2.21</version>
+      <version>${rxjava.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
+      <version>${jansi.version}</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
- Upgrade micronaut test to 4.2.0
- Upgrade micronaut gql to 4.2.1
- Upgrade logback to 1.4.14
- Upgrade restassured to 5.4.0
- Upgrade Maven exec plugin to 3.1.1
- Upgrade Maven Resources plugin to 3.3.1
- Upgrade Maven compiler plugin to 3.12.1
- Upgrade frontend-maven-plugin to 1.15.0

- Add jansi dependency 2.4.1 (used by logback)

resolves #45 